### PR TITLE
feat: add in global attributes in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ yarn build
 3. From your Backstage directory run the following where `$INSTALL_PATH` is the path of this repo:
 
 ```bash
-yarn add @qm/plugin-analytics-module-qm@file:$INSTALL_PATH
+yarn add @qm/plugin-analytics-module-qm@link:$INSTALL_PATH
 ```
+
+Note: If making changes to `config.d.ts` against a Backstage instance started with `backstage-cli package start`,
+changes will not take effect till the next `backstage-cli package start`
 
 ## Contributing
 

--- a/config.d.ts
+++ b/config.d.ts
@@ -4,48 +4,56 @@ export interface Config {
       qm: {
         /**
          * Controls if plugin is on or off
-         * NOTE: Visibility applies to only this field
          * @visibility frontend
          */
         enabled: boolean;
         /**
          *  Turns on console.debug messages
-         * NOTE: Visibility applies to only this field
          * @visibility frontend
          */
         debug: boolean;
         /**
          * Sends events to console log instead of quantum metric
-         * NOTE: Visibility applies to only this field
          * @visibility frontend
          */
         test: boolean;
         /**
          * Quantum Metric CDN source URL
-         * NOTE: Visibility applies to only this field
          * @visibility frontend
          */
         src: string;
         /**
          * Controls wether or not to block on Quantum Metric API
-         * NOTE: Visibility applies to only this field
          * @visibility frontend
          */
         async: number;
-        /**
-         * Global attributes to be included on all events
-         * NOTE: Visibility applies to only this field
-         * @visibility frontend
-         */
-        attributes: any;
 
-        /**
-         * Event mapping of Backstage events like navigation/search to their Quantum Metric event IDs
-         * @deepvisibility frontend
-         */
+        // Global attributes to be included on all events
+        attributes: {
+          /**
+           * Key of global attribute field to include on all events sent to Quantum Metric
+           * @visibility frontend
+           */
+          name: string;
+          /**
+           * Value of global attribute field to include on all events sent to Quantum Metric
+           * @visibility frontend
+           */
+          value: string | number | boolean;
+        }[];
+
+        // Event mapping of Backstage events like navigation/search to their Quantum Metric event IDs
         events: {
           mappings: {
+            /**
+             * Backstage event action like 'search' || 'click' to map to the Quantum Metric event ID
+             * @visibility frontend
+             */
             name: string;
+            /**
+             * Quantum Metric event ID to send when the above event name is detected.
+             * @visibility frontend
+             */
             id: number | string;
           }[];
         };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "prepack": "backstage-cli package prepack",
     "prettier:check": "prettier --check .",
     "postpack": "backstage-cli package postpack",
-    "release": "release-it"
+    "release": "release-it",
+    "dev": "nodemon -e js,ts --exitcrash --ignore dist --exec \"yarn run build && cp config.d.ts dist/\""
   },
   "dependencies": {
     "@backstage/config": "^1.1.1",
@@ -57,5 +58,6 @@
     "dist",
     "config.d.ts"
   ],
-  "configSchema": "config.d.ts"
+  "configSchema": "config.d.ts",
+  "module": "./dist/index.esm.js"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { QuantumMetric } from './api';
+export * from './api';


### PR DESCRIPTION
## What this MR does

Global attributes allows for adding attributes to all events sent through the Quantum Metric analytics plugin.

With a configuration like:

```YAML
app:
  analytics:
    qm:
      attributes:
        - name: environment
          value: development
        - name: version
          value: 0.0.1
```

Quantum Metric event details will show:

```JSON
{
  "environment": "development",
  "version": "0.0.1"
}
```

In the case of attributes included from Backstage events via the event transformers, those will also be included with the global attributes.

For instance a search event with the default event transformer will include a `results-found` attribute. Combined with the above the event details page will look like:

```JSON
{
  "results-found": 10,
  "environment": "development",
  "version": "0.0.1"
}
```

### Attribute Key Collions
In the case of a collision global attributes will take precedence.