### PR TITLE
fix: update release to run build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           persist-credentials: false
       - run: yarn install
+      - run: yarn build
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}


### PR DESCRIPTION
## What This MR Does

Adds a yarn build before publishing so the `dist` folder is created before we publish